### PR TITLE
add troubleshooting to deployment doc

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -34,6 +34,8 @@ spec:
                   - mountPath: /app-root/lightspeed-stack.yaml
                     name: lightspeed-stack
                     subPath: lightspeed-stack.yaml
+                  - mountPath: /tmp/data/feedback
+                    name: llama-storage
             volumes:
               - configMap:
                   name: lightspeed-stack
@@ -59,31 +61,20 @@ llama_stack:
 user_data_collection:
   feedback_enabled: false
   feedback_storage: "/tmp/data/feedback"
-  transcripts_enabled: false
-  transcripts_storage: "/tmp/data/transcripts"
-  data_collector:
-    enabled: false
-    ingress_server_url: null
-    ingress_server_auth_token: null
-    ingress_content_service_name: null
-    collection_interval: 7200
-    cleanup_after_send: true
-    connection_timeout_seconds: 30
 authentication:
   module: "noop"
 ```
 
 ## Troubleshooting
+> [!WARNING]
+> Currently there is not full support for RHDH + Lightspeed Core as some endpoints are missing and/or been changed. Please be aware that some functionality may differ than what you are used to with Road Core + RHDH while these changes are being made.
 
 In the current state you need to add the following to your `RHDH` configuration file to enable Lightspeed:
 
 ```yaml
 lightspeed:
   servers:
-    - id: <your-id>
+    - id: vllm
       url: <your-url>
       token: <your-token>
 ```
-
-> [!IMPORTANT]
-> Since we need to add inference servers in `Llama Stack` as well as `Lightspeed` (temporarily?), you must ensure that the `id` of your `Lightspeed` server is `vllm`.


### PR DESCRIPTION
- Updates the `DEPLOYMENT.md` document to remove un-required items from the Lightspeed stack config and also add the shared dir that is required for feedback storage to the Lightspeed Core container.
- Adds a warning explaining that RHDH + Lightspeed Core is still in development and some items may not work as expected