### PR TITLE
Add support for rag-content image, RAG toolgroup and vectordb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .llama
+
+# Don't track the RAG data and model from the rag-content image
+embeddings_model
+vector_db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+RAG_CONTENT_IMAGE ?= quay.io/redhat-ai-dev/rag-content:release-1.7-lcs
+
+default: help
+
+get-rag: ## Download a copy of the RAG embedding model and vector database
+	podman create --replace --name tmp-rag-container $(RAG_CONTENT_IMAGE) true
+	rm -rf vector_db embeddings_model
+	podman cp tmp-rag-container:/rag/vector_db vector_db
+	podman cp tmp-rag-container:/rag/embeddings_model embeddings_model
+	podman rm tmp-rag-container
+
+help: ## Show this help screen
+	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+	@echo ''
+	@echo 'Available targets are:'
+	@echo ''
+	@grep -E '^[ a-zA-Z0-9_.-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-33s\033[0m %s\n", $$1, $$2}'
+	@echo ''

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Redhat-Ai-Dev Llama Stack
+# Redhat-AI-Dev Llama Stack
 
 ## Image Availability
 
@@ -6,9 +6,10 @@ This image is built and available at [quay.io/redhat-ai-dev/llama-stack:latest](
 
 ## Usage
 
-There are 4 environment variables that you are able to set, broken up below into **required** and **optional**.
+There is a make target and 4 environment variables that you are able to set, broken up below into **required** and **optional**.
 
 ### Required
+- `make get-rag`: Gets the RAG data and the embeddings model from the rag-content image registry to your local project dir
 - `$VLLM_URL`: The url of your server, i.e. `http://localhost:8080/v1`
 - `VLLM_API_KEY`: API key for the `$VLLM_URL`
 
@@ -18,7 +19,15 @@ There are 4 environment variables that you are able to set, broken up below into
 
 Run:
 ```
-podman run -it -p 8321:8321 -e VLLM_URL=<your-url> -e VLLM_API_KEY=<api-key> quay.io/redhat-ai-dev/llama-stack:latest
+podman run -it -p 8321:8321 -e VLLM_URL=<your-url> -e VLLM_API_KEY=<api-key> -v ./embeddings_model:/app-root/embeddings_model -v ./vector_db/rhdh_product_docs:/app-root/vector_db/rhdh_product_docs quay.io/redhat-ai-dev/llama-stack:latest
+```
+
+### Setting the DEBUG option
+
+If you want DEBUG logging from the llama-stack server, set the following environment variable when executing podman run
+
+```
+-e LLAMA_STACK_LOGGING=all=DEBUG
 ```
 
 #### Using the Ollama provider

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "trl>=0.18.2",
     "greenlet",
     "torch",
+    "sentence-transformers>=5.0.0",
 ]
 requires-python = "==3.12.*"
 readme = "README.md"

--- a/run.yaml
+++ b/run.yaml
@@ -24,6 +24,13 @@ metadata_store:
   db_path: .llama/distributions/ollama/registry.db
   namespace: null
   type: sqlite
+models:
+- model_id: sentence-transformers/all-mpnet-base-v2
+  metadata:
+      embedding_dimension: 768
+  model_type: embedding
+  provider_id: sentence-transformers
+  provider_model_id: "/app-root/embeddings_model"
 providers:
   agents:
   - config:
@@ -75,6 +82,9 @@ providers:
     #   provider_type: remote::openai
     #   config:
     #     api_key: ${env.OPENAI_API_KEY}
+    - provider_id: sentence-transformers
+      provider_type: inline::sentence-transformers
+      config: {}
   post_training:
   - config:
       checkpoint_format: huggingface
@@ -107,9 +117,12 @@ providers:
     provider_id: meta-reference
     provider_type: inline::meta-reference
   tool_runtime:
-    - provider_id: model-context-protocol
-      provider_type: remote::model-context-protocol
-      config: {}
+  - provider_id: model-context-protocol
+    provider_type: remote::model-context-protocol
+    config: {}
+  - provider_id: rag-runtime 
+    provider_type: inline::rag-runtime
+    config: {}
   vector_io:
   - config:
       kvstore:
@@ -118,6 +131,13 @@ providers:
         type: sqlite
     provider_id: faiss
     provider_type: inline::faiss
+  - provider_id: rhdh-docs 
+    provider_type: inline::faiss
+    config:
+      kvstore:
+        type: sqlite
+        namespace: null
+        db_path: /app-root/vector_db/rhdh_product_docs/1.7/faiss_store.db
 scoring_fns: []
 server:
   auth: null
@@ -128,4 +148,12 @@ server:
   tls_certfile: null
   tls_keyfile: null
 shields: []
-vector_dbs: []
+tool_groups:
+- provider_id: rag-runtime
+  toolgroup_id: builtin::rag
+  description: "Only use for questions specifically about Red Hat Developer Hub (RHDH). Searches technical documentation for RHDH installation, discovery, configuration, release, upgrade, control access, integration, observability, and extending with plugins. Do not use for any other topic outside RHDH."
+vector_dbs:
+- embedding_dimension: 768
+  embedding_model: sentence-transformers/all-mpnet-base-v2
+  provider_id: rhdh-docs
+  vector_db_id: rhdh-product-docs-1_7


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
- Adds support for rag-content image registry from https://github.com/redhat-ai-dev/rhdh-rag-content
- Updates run.yaml to enable rag toolgroup, embeddings model and vector db
- Update Makefile and README to instruct local dev workflow
   - On OpenShift, the sidecar will be mounting the RAG data and embeddings model from an emptyDir volume

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->
https://issues.redhat.com/browse/RHDHPAI-985

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [x] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
Two extra steps, 
- Run `make get-rag` to download RAG data, embeddings model
- podman build like usual
- podman run updated to mount RAG data, embeddings model; refer README