### PR TITLE
fix: add google-auth as direct dependency for Vertex AI provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "pydantic>=2.10.6",
     "httpx",
     "chardet",
+    "google-auth>=2.0.0",
 ]
 requires-python = "==3.12.*"
 readme = "README.md"


### PR DESCRIPTION
## Problem

The Vertex AI inference provider imports `google.auth` but the `google-auth`
package is not listed as a direct dependency in `pyproject.toml`. Since the
Containerfile copies only `pyproject.toml` (not `uv.lock`) and runs
`uv sync --no-dev`, the package is not installed in the built image.

This causes the llama-stack container to crash on startup with:

```
ModuleNotFoundError: No module named 'google.auth'
```

Affects `quay.io/redhat-ai-dev/llama-stack:latest` and `0.1.4`.

## Fix

Add `google-auth>=2.0.0` as a direct dependency in `pyproject.toml`.

## Verification

- Built the image locally with `buildah build` (matching CI pipeline)
- Confirmed `google-auth 2.52.0` is installed and importable in the new image

## Related

- Jira: [RHDHBUGS-2890](https://redhat.atlassian.net/browse/RHDHBUGS-2890)